### PR TITLE
docs: clarify isRooted result field in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ This is the recommended method for basic root/jailbreak detection.
 It runs a combination of the most reliable detection heuristics for the platform.
 Works on both Android and iOS.
 
+Example:
+
+```ts
+import { IsRoot } from 'capacitor-is-root';
+
+const rootResult = await IsRoot.isRooted();
+if (rootResult.result) {
+  console.log('Device is rooted');
+}
+```
+
+> `DetectionResult` uses the `result` field (`boolean`).
+
 **Returns:** <code>Promise&lt;<a href="#detectionresult">DetectionResult</a>&gt;</code>
 
 **Since:** 1.0.0

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Works on both Android and iOS.
 Example:
 
 ```ts
-import { IsRoot } from 'capacitor-is-root';
+import { IsRoot } from '@capgo/capacitor-is-root';
 
 const rootResult = await IsRoot.isRooted();
 if (rootResult.result) {


### PR DESCRIPTION
## Summary
- add an explicit `isRooted()` usage example in README
- clarify that `DetectionResult` uses the `result` boolean field

Fixes confusion reported in #2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a code example demonstrating async usage of isRooted(), showing how to call it and check the boolean result.
  * Clarified that DetectionResult exposes a boolean result field and made minor formatting improvements to the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->